### PR TITLE
v 118-120 Corrections and 'improvements'

### DIFF
--- a/code/smallc22/cc.h
+++ b/code/smallc22/cc.h
@@ -2,26 +2,39 @@
 ** CC.H -- Symbol Definitions for Small-C compiler.
 */
 
+#ifndef HSTBPW
+#define HSTBPW sizeof(int)	/* 118 FJS+ host bytes per word */
+#endif
+
 /*
 ** machine dependent parameters
 */
+#ifndef BPW
+#ifndef TGT32
 #define BPW     2   /* bytes per word */
 #define LBPW    1   /* log2(BPW) */
-#define SBPC    1   /* stack bytes per character */
+#else
+#define BPW     4   /* bytes per word (32 bit target ints) */ /* 120 FJS+ */
+#define LBPW    2   /* log2(BPW) */
+#endif
+#endif
+#define SBPC    1   /* stack bytes per character (1 or BPW?) */
 #define ERRCODE 7   /* op sys return code */
 
 /*
 ** symbol table format
 */
+#define SMLL     2	/* 2-byte packed 'small' integer value 118 FJS+ */
+
 #define IDENT    0
 #define TYPE     1
 #define CLASS    2
-#define SIZE     3
-#define OFFSET   5
+#define SIZE     3	/* 2-byte 'small' int value */
+#define OFFSET   5	/* 2-byte 'small' int value */
 #define NAME     7
 
-#define SYMAVG  16
-#define SYMMAX  20
+#define SYMAVG  16	/* = SYMMAX - 4 */
+#define SYMMAX  20	/* = NAME + NAMEMAX */
 
 /*
 ** symbol table parameters
@@ -80,7 +93,7 @@
 /*
 ** "switch" table
 */
-#define SWSIZ   (2*BPW)
+#define SWSIZ   2		/* 118 FJS* pointer arith: 2 was (2*BPW) */
 #define SWTABSZ (90*SWSIZ)
 
 /*
@@ -148,6 +161,7 @@
 **  1 = primary register (pr in comments)
 **  2 = secondary register (sr in comments)
 **  b = byte
+**  h = half word (short)			120 FJS+
 **  f = jump on false condition
 **  l = current literal pool label number
 **  m = memory reference by label
@@ -270,5 +284,32 @@
 #define SUBbpn  105   /* sub n from mem byte thru sr ptr */
 #define SUBwpn  106   /* sub n from mem word thru sr ptr */
 
+#ifndef DOSHRT
 #define PCODES  107   /* size of code[] */
+#else
+/* TBD - 120 FJS+ for 16-bit shorts - */
+#define SHRT_   107   /* define shorts (part 1) */	/* prefix */
 
+#define SHRTn   108   /* define short of value n */
+#define SHRTr0  109   /* define r shorts of value 0 */
+#define GETh1m  110   /* get short into pr from mem thru label */
+#define GETh1mu 111   /* get unsigned short into pr from mem thru label */
+#define GETh1p  112   /* get short into pr from mem thru sr ptr */
+#define GETh1pu 113   /* get unsigned short into pr from mem thru sr ptr */
+#define PUThm1  114   /* put pr short in mem thru label */
+#define PUThp1  115   /* put pr short in mem thru sr ptr */
+
+#ifndef OPTSHRT
+#define PCODES  116   /* size of code[] */
+#else
+		/* optimizer-generated - */
+#define ADDhpn  116   /* add n to mem short thru sr ptr */
+#define DEChp   117   /* dec mem short thru sr ptr */
+#define GETh1s  118   /* get short into pr from stack */
+#define GETh1su 119   /* get unsigned short into pr from stack */
+#define INChp   120   /* inc short in mem thru sr ptr */
+#define SUBhpn  121   /* sub n from mem short thru sr ptr */
+
+#define PCODES  122   /* size of code[] */
+#endif
+#endif

--- a/code/smallc22/cc2.c
+++ b/code/smallc22/cc2.c
@@ -29,7 +29,7 @@ preprocess() {
         if (eof) return;
     }
     else {
-        inline();
+        linein();               /* 119 FJS* linein was inline */
         return;
     }
     pptr = -1;
@@ -133,7 +133,7 @@ keepch(char c) {
 
 ifline() {
     while (1) {
-        inline();
+        linein();               /* 119 FJS* linein was inline */
         if (eof) return;
         if (match("#ifdef")) {
             ++iflevel;
@@ -174,7 +174,8 @@ ifline() {
     }
 }
 
-inline() {           /* numerous revisions */
+/* 119 FJS* linein was inline - */
+linein() {           /* numerous revisions */
     int k, unit;
     poll(1);           /* allow operator interruption */
     if (input == EOF)

--- a/code/smallc22/cc4.c
+++ b/code/smallc22/cc4.c
@@ -504,7 +504,7 @@ toseg(int newseg) {
 /*
 ** declare variable, allowing global scope
 */
-public(int ident, int isGlobal) {
+publik(int ident, int isGlobal) { /* 119 FJS* publik was keyword public */
     if (ident == FUNCTION)
         toseg(CODESEG);
     else
@@ -601,7 +601,7 @@ dumpzero(int size, int count) {
 */
 peep(int *seq) {
     int *next, *count, *pop, n, skip, tmp, reply;
-    char c;
+    char c, *cp;                /* 118 FJS* added *cp */
     next = snext;
     count = seq++;
     while (*seq) {
@@ -619,7 +619,8 @@ peep(int *seq) {
                 break;
             return (NO);
         case comm: 
-            if (*next & COMMUTES)
+            /* if (*next & COMMUTES) */ /* 118 FJS*- wrong (incomplete) */
+            if (*(cp = code[*next]) & COMMUTES) /* 118 FJS*+ corrected */
                 break;
             return (NO);
         case _pop:

--- a/code/smallc22/notice.h
+++ b/code/smallc22/notice.h
@@ -1,5 +1,5 @@
 /*
 ** NOTICE.H -- Small C Signon Notice.
 */
-#define VERSION "Small C, Version 2.2, Revision Level 117\n"
+#define VERSION "Small C, Version 2.2, Revision Level 120\n"
 #define CRIGHT1 "Copyright 1982, 1983, 1985, 1988 J. E. Hendrix\n\n"


### PR DESCRIPTION
v118 - Correct pointer arithmetic errors, dodo() 'continue' error, and peep() COMMUTES error.  Macro HSTBPW also gives some cross-compile support.
v119 - Remove cross-compile keyword conflicts for const, inline, public, and double.
v120 - Added adjacent string catenation.  Laid groundwork for 32-bit targets w/ short ints.
TBD - target right-to-left function arg eval/stack. Fix library #ASM sections to allow host 32-bit and host R-to-L libraries.